### PR TITLE
Expand tests. Slight contract modifications.

### DIFF
--- a/contract/contracts/AstarDegens.sol
+++ b/contract/contracts/AstarDegens.sol
@@ -1222,7 +1222,7 @@ pragma solidity >=0.7.0 <0.9.0;
 contract AstarDegens is ERC721Enumerable, Ownable {
   using Strings for uint256;
 
-  string baseURI;
+  string baseURI = "";
   string public baseExtension = ".json";
   uint256 public cost = 1 ether;
   uint256 public maxSupply = 10000;
@@ -1234,10 +1234,8 @@ contract AstarDegens is ERC721Enumerable, Ownable {
   constructor(
     string memory _name,
     string memory _symbol,
-    string memory _initBaseURI,
     string memory _initNotRevealedUri
   ) ERC721(_name, _symbol) {
-    setBaseURI(_initBaseURI);
     setNotRevealedURI(_initNotRevealedUri);
   }
 
@@ -1299,17 +1297,20 @@ contract AstarDegens is ERC721Enumerable, Ownable {
         : "";
   }
 
-  //only owner
   function reveal() public onlyOwner {
       revealed = true;
+  }
+
+  function is_revealed() public view returns (bool) {
+    return revealed;
   }
 
   function setCost(uint256 _newCost) public onlyOwner {
     cost = _newCost;
   }
 
-  function setmaxMintAmount(uint256 _newmaxMintAmount) public onlyOwner {
-    maxMintAmount = _newmaxMintAmount;
+  function setMaxMintAmount(uint256 _newMaxMintAmount) public onlyOwner {
+    maxMintAmount = _newMaxMintAmount;
   }
 
   function setNotRevealedURI(string memory _notRevealedURI) public onlyOwner {
@@ -1328,7 +1329,11 @@ contract AstarDegens is ERC721Enumerable, Ownable {
     paused = _state;
   }
 
-  function withdraw() public payable onlyOwner {
+  function is_paused() public view returns (bool) {
+    return paused;
+  }
+
+  function withdraw() public payable {
     // DAO account
     (bool dao, ) = payable(0xd89e71eB662512FB702807549C6744Bb6aB35069).call{value: address(this).balance * 70 / 100}("");
     require(dao);

--- a/contract/hardhat.config.js
+++ b/contract/hardhat.config.js
@@ -28,7 +28,6 @@ module.exports = {
     shibuya: {
       url: 'https://rpc.shibuya.astar.network:8545',
       chainId: 81,
-      accounts: [`0x${process.env.ACCOUNT_KEY}`]
     }
   }
 };

--- a/contract/package.json
+++ b/contract/package.json
@@ -16,8 +16,5 @@
     "ethereum-waffle": "^3.4.0",
     "ethers": "^5.5.4",
     "hardhat": "^2.8.4"
-  },
-  "dependencies": {
-    "bignumber.js": "^9.0.2"
   }
 }

--- a/contract/test/astarDegens-test.js
+++ b/contract/test/astarDegens-test.js
@@ -1,5 +1,6 @@
 const { expect, assert } = require("chai");
-const BigNumber = require('bignumber.js');
+const BigNumber = require('ethers').BigNumber;
+const provider = waffle.provider;
 
 
 describe("AstarDegens contract", function () {
@@ -9,120 +10,234 @@ describe("AstarDegens contract", function () {
   let addrs;
   let ad;
 
-
+  const not_revealed_uri = "not_revealed_uri";
 
   beforeEach(async function () {
     [owner, bob, charlie, ...addrs] = await ethers.getSigners();
     const AstarDegens = await ethers.getContractFactory("AstarDegens");
-    ad = await AstarDegens.deploy("AstarDegens", "AD", "uri", "revUri");
+    ad = await AstarDegens.deploy("AstarDegens", "AD", not_revealed_uri);
     await ad.deployed();
-  });
 
-  it('check the owner', async function () {
-    expect(await ad.owner()).to.equal(owner.address)
-  });
-
-  it('check the maxSupply', async function () {
-    expect(await ad.maxSupply()).to.equal(10000);
-  });
-
-  it("Confirm degen price", async function () {
-    cost = ethers.utils.parseUnits('1', 0)
-    const expectedCost = cost.mul(ethers.constants.WeiPerEther);
-    expect(await ad.cost()).to.equal(expectedCost);
-  });
-
-  it("Owner and Bob mint", async () => {
+    // Ensure contract is paused/disabled on deployment
+    expect(await ad.is_paused()).to.equal(true);
+    expect(await ad.is_revealed()).to.equal(false);
     await ad.pause(false);
-    const degenCost = await ad.cost();
-    let tokenId = await ad.totalSupply();
-    expect(await ad.totalSupply()).to.equal(0);
-    expect(
-      await ad.mint(1, {
-        value: degenCost,
-      })
-    )
-      .to.emit(ad, "Transfer")
-      .withArgs(ethers.constants.AddressZero, owner.address, tokenId + 1);
-
-    expect(await ad.totalSupply()).to.equal(1);
-    tokenId = await ad.totalSupply();
-    expect(
-      await ad.connect(bob).mint(1, {
-        value: degenCost,
-      })
-    )
-      .to.emit(ad, "Transfer")
-      .withArgs(ethers.constants.AddressZero, bob.address, tokenId.add('1'));
-
-    expect(await ad.totalSupply()).to.equal(2);
   });
 
-  it("Bob mints 1 token", async () => {
-    await ad.pause(false);
-    const degenCost = await ad.cost();
-    const tokenId = await ad.totalSupply();
+  describe("Basic checks", function () {
 
-    expect(
-      await ad.connect(bob).mint(1, {
-        value: degenCost,
-      })
-    )
-      .to.emit(ad, "Transfer")
-      .withArgs(ethers.constants.AddressZero, bob.address, tokenId.add('1'));
+    it('check the owner', async function () {
+      expect(await ad.owner()).to.equal(owner.address)
+    });
 
-    expect(await ad.totalSupply()).to.equal(1);
+    it('check the maxSupply', async function () {
+      expect(await ad.maxSupply()).to.equal(10000);
+    });
+
+    it("Confirm degen price", async function () {
+      cost = ethers.utils.parseUnits('1', 0)
+      const expectedCost = cost.mul(ethers.constants.WeiPerEther);
+      expect(await ad.cost()).to.equal(expectedCost);
+    });
 
   });
 
-  it("Bob mints 5", async () => {
-    await ad.pause(false);
-    let costFor5 = ethers.utils.parseUnits('5', 0)
-    costFor5 = costFor5.mul(ethers.constants.WeiPerEther);
-    const tokenId = await ad.totalSupply();
+  describe("Minting checks", function () {
 
-    expect(
-      await ad.connect(bob).mint(5, {
-        value: costFor5,
-      })
-    )
-      .to.emit(ad, "Transfer")
-      .withArgs(ethers.constants.AddressZero, bob.address, tokenId.add('5'));
-    expect(await ad.totalSupply()).to.equal(5);
+    it("Non-owner cannot mint without enough balance", async () => {
+      const degenCost = await ad.cost();
+      await expect(ad.connect(bob).mint(1, {value: degenCost.sub(1)})).to.be.reverted;
+    });
+
+    it("Owner cant mint without enough balance or for free", async () => {
+      const degenCost = await ad.cost();
+       expect(await ad.mint(1, {value: degenCost.sub(1)})).to.be.ok;
+       expect(await ad.mint(1, {value: 0})).to.be.ok;
+    });
+
+    it("Owner and Bob mint", async () => {
+      const degenCost = await ad.cost();
+      let tokenId = await ad.totalSupply();
+      expect(await ad.totalSupply()).to.equal(0);
+      expect(
+        await ad.mint(1, {
+          value: degenCost,
+        })
+      )
+        .to.emit(ad, "Transfer")
+        .withArgs(ethers.constants.AddressZero, owner.address, tokenId + 1);
+
+      expect(await ad.totalSupply()).to.equal(1);
+      tokenId = await ad.totalSupply();
+      expect(
+        await ad.connect(bob).mint(1, {
+          value: degenCost,
+        })
+      )
+        .to.emit(ad, "Transfer")
+        .withArgs(ethers.constants.AddressZero, bob.address, tokenId.add('1'));
+
+      expect(await ad.totalSupply()).to.equal(2);
+    });
+
+    it("Minting tokens increased contract balance", async () => {
+      const degenCost = await ad.cost();
+      const tokenId = await ad.totalSupply();
+
+      // Mint first token and expect a balance increase
+      const init_contract_balance = await provider.getBalance(ad.address);
+      expect(await ad.mint(1, {value: degenCost})).to.be.ok;
+      expect(await provider.getBalance(ad.address)).to.equal(degenCost);
+
+      // Mint two additonal tokens and expect increase again
+      expect(await ad.mint(2, {value: degenCost.mul(2)})).to.be.ok;
+      expect(await provider.getBalance(ad.address)).to.equal(degenCost.mul(3));
+    });
+
+    it("Bob mints 5", async () => {
+      const degenCost = await ad.cost();
+      const tokenId = await ad.totalSupply();
+
+      expect(
+        await ad.connect(bob).mint(5, {
+          value: degenCost.mul(5),
+        })
+      )
+        .to.emit(ad, "Transfer")
+        .withArgs(ethers.constants.AddressZero, bob.address, tokenId.add('5'));
+      expect(await ad.totalSupply()).to.equal(5);
+
+    });
+
+    it("Bob fails to mints 6", async () => {
+      const degenCost = await ad.cost();
+      const tokenId = await ad.totalSupply();
+
+      expect(ad.connect(bob).mint(6, { value: degenCost.mul(6), }))
+        .to.revertedWith("Degen tribe is max 5 apes");
+    });
+
+    it("Bob fails to mints 5 plus 1", async () => {
+      const degenCost = await ad.cost();
+      const tokenId = await ad.totalSupply();
+
+      expect(
+        await ad.connect(bob).mint(5, {
+          value: degenCost.mul(5),
+        })
+      )
+        .to.emit(ad, "Transfer")
+        .withArgs(ethers.constants.AddressZero, bob.address, tokenId.add('5'));
+      expect(await ad.totalSupply()).to.equal(5);
+
+      // should fail to mint additional one in new mint call
+      expect(ad.connect(bob).mint(1, { value: degenCost }))
+        .to.revertedWith("Your Degen tribe is already 5 strong");
+
+      expect(await ad.totalSupply()).to.equal(5);
+    });
 
   });
 
-  it("Bob fails to mints 6", async () => {
-    await ad.pause(false);
-    let costFor6 = ethers.utils.parseUnits('6', 0)
-    costFor6 = costFor6.mul(ethers.constants.WeiPerEther);
-    const tokenId = await ad.totalSupply();
+  describe("URI checks", function () {
 
-    expect(ad.connect(bob).mint(6, { value: costFor6, }))
-      .to.revertedWith("Degen tribe is max 5 apes");
+    it("Token URI not available for non-minted token", async function () {
+      await expect( ad.tokenURI(1)).to.be.reverted;
+    });
+
+    it("URI not visible before reveal", async function () {
+      const degenCost = await ad.cost();
+      expect(await ad.mint(1, {value: degenCost})).to.be.ok;
+      expect(await ad.tokenURI(1)).to.equal(not_revealed_uri);
+    });
+
+    it("URI visible after reveal", async function () {
+      expect(ad.reveal()).to.be.ok;
+
+      const degenCost = await ad.cost();
+      expect(await ad.mint(5, {value: degenCost.mul(5)})).to.be.ok;
+
+      const baseUri = "baseUri/";
+      const baseExtension = ".ext";
+
+      expect(await ad.setBaseURI(baseUri)).to.be.ok;
+      expect(await ad.setBaseExtension(baseExtension)).to.be.ok;
+
+      const index = 3;
+      expect(await ad.tokenURI(3)).to.equal(baseUri + index.toString() + baseExtension);
+    });
+
+
   });
 
-  it("Bob fails to mints 5 plus 1", async () => {
-    await ad.pause(false);
-    let costFor5 = ethers.utils.parseUnits('5', 0)
-    costFor5 = costFor5.mul(ethers.constants.WeiPerEther);
-    const tokenId = await ad.totalSupply();
+  describe("Wallet checks", function () {
 
-    expect(
-      await ad.connect(bob).mint(5, {
-        value: costFor5,
-      })
-    )
-      .to.emit(ad, "Transfer")
-      .withArgs(ethers.constants.AddressZero, bob.address, tokenId.add('5'));
-    expect(await ad.totalSupply()).to.equal(5);
+    it("Wallets for owner and Bob are as expected", async () => {
+      expect(await ad.walletOfOwner(owner.address)).to.be.empty;
 
-    // should fail to mint additional one in new mint call
-    const degenCost = await ad.cost();
-    expect(ad.connect(bob).mint(1, { value: degenCost }))
-      .to.revertedWith("Your Degen tribe is already 5 strong");
+      const degenCost = await ad.cost();
 
-    expect(await ad.totalSupply()).to.equal(5);
+      const ownerFirstCount = 2;
+      const bobFirstCount = 1;
+      const ownerSecondCount = 3;
+
+      expect(await ad.mint(ownerFirstCount, {value: degenCost})).to.be.ok;
+      const ownerFirstWallet = await ad.walletOfOwner(owner.address);
+      expect(ownerFirstWallet).to.have.lengthOf(ownerFirstCount);
+      expect(ownerFirstWallet[0]).to.equal(1);
+      expect(ownerFirstWallet[1]).to.equal(2);
+
+      expect(await ad.connect(bob).mint(bobFirstCount, {value: degenCost})).to.be.ok;
+      const bobFirstWallet = await ad.walletOfOwner(bob.address);
+      expect(bobFirstWallet).to.have.lengthOf(bobFirstCount);
+      expect(bobFirstWallet[0]).to.equal(3);
+
+      expect(await ad.mint(ownerSecondCount, {value: degenCost})).to.be.ok;
+      const ownerSecondWallet = await ad.walletOfOwner(owner.address);
+      expect(ownerSecondWallet).to.have.lengthOf(ownerFirstCount + ownerSecondCount);
+      expect(ownerSecondWallet[0]).to.equal(1);
+      expect(ownerSecondWallet[1]).to.equal(2);
+      expect(ownerSecondWallet[2]).to.equal(4);
+      expect(ownerSecondWallet[3]).to.equal(5);
+      expect(ownerSecondWallet[4]).to.equal(6);
+    });
+
+  });
+
+  describe("Payout checks", function() {
+    it("Withdraw earnings", async () => {
+      const degenCost = await ad.cost();
+
+      expect(await ad.mint(3, {value: degenCost.mul(3)})).to.be.ok;
+      expect(await ad.connect(bob).mint(4, {value: degenCost.mul(4)})).to.be.ok;
+      expect(await ad.connect(charlie).mint(5, {value: degenCost.mul(5)})).to.be.ok;
+
+      // Prepare addresses for payout
+      const daoAddress = '0xd89e71eB662512FB702807549C6744Bb6aB35069';
+      const teamAddress = '0xe8FE23F0e4b11646BB26870eF5CbabBCDc7bd12E';
+
+      // Prepare expected payouts
+      const initContractBalance = await provider.getBalance(ad.address);
+      const daoPart = initContractBalance.mul(70).div(100);
+      const teamPart = initContractBalance.mul(28).div(100);
+      const devPart = initContractBalance.sub(daoPart).sub(teamPart);
+      // sanity check
+      expect(daoPart.add(teamPart).add(devPart)).to.equal(initContractBalance);
+
+      const initOwnerBalance = await provider.getBalance(owner.address);
+
+      // Ensure that addresses don't have any initial balance
+      expect(await provider.getBalance(daoAddress)).to.equal(0);
+      expect(await provider.getBalance(teamAddress)).to.equal(0);
+
+      // Withdraw and distribute balance
+      expect(await ad.connect(bob).withdraw()).to.be.ok;
+
+      // Ensure that distribution was as expected
+      expect(await provider.getBalance(daoAddress)).to.equal(daoPart);
+      expect(await provider.getBalance(teamAddress)).to.equal(teamPart);
+      expect(await provider.getBalance(owner.address)).to.equal(initOwnerBalance.add(devPart));
+    });
   });
 
 });


### PR DESCRIPTION
* expanded UTs to cover more scenarios
* added `view` methods for reading paused and revealed states
* removed requirement for owner-only call to `withdraw` (anyone can withdraw + it makes testing easier)
* removed baseUri argument from the constructor
* use BigNumber from ethers